### PR TITLE
Allow connection with AuthSession cookie

### DIFF
--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -58,10 +58,12 @@ def _stringify_params(params):
 
 
 class RemoteServer(object):
-    def __init__(self, server, user=None, password=None, **kwargs):
+    def __init__(self, server, user=None, password=None, cookie=None, **kwargs):
         self._server = server
         auth = aiohttp.BasicAuth(user, password) if user else None
-        self._http_session = aiohttp.ClientSession(auth=auth, **kwargs)
+        headers = {'Cookie': 'AuthSession=' + cookie} if cookie else None
+        self._http_session = aiohttp.ClientSession(headers=headers, auth=auth,
+                                                   **kwargs)
         self._databases = {}
 
     async def __aenter__(self):

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -13,6 +13,11 @@ async def main_with():
         async for doc in database.docs(["db-hta"]):
             print(doc)
 
+    async with CouchDB(
+        "http://localhost:5984", cookie="ZGVtb0B0b2x0ZWNrLmNvbT..."
+    ) as couchdb:
+        await couchdb["_users"]
+
 
 if __name__ == "__main__":
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
Hey @bmario :wave:, thanks for the good job! That's the only async CouchDB lib I've found, that works with modern Python.

---

Upon first connection with `username` and `password`, CouchDB servers
install an `AuthSession` cookie in the browser.

This commits allows connecting using this cookie, e.g.:

    CouchDB("http://localhost:5984", cookie="ZGVtb0B0b2x0ZWNrLmNvbT...")