### PR TITLE
Implement Database.save(doc)

### DIFF
--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -110,6 +110,11 @@ class Database(RemoteDatabase):
 
             params["bookmark"] = result_chunk["bookmark"]
 
+    async def save(self, doc):
+        document = Document(self, doc["_id"])
+        document.update(doc)
+        return await document.save()
+
     def update_docs(self, ids, create=False):
         return BulkOperation(self, ids, create)
 


### PR DESCRIPTION
There are cases when it's not handy to use the `Document` class. An
example is when we don't know whether the document exists or not,
whether `Document.create()` or `Document.fetch()` should be called.

I propose to implement `Database.save(doc)`, similarly to what
couchdb-python proposes [1]:

```python
try:
    doc = await db["counter"]
except NotFoundError:
    doc = {"_id": "counter", "value": 1}

doc["value"] += 1
await db.save(doc)
```

\[1]: https://couchdb-python.readthedocs.io/en/latest/client.html#couchdb.client.Database.save

---

Note: I also started implementing a wrapper like this:

```python
async def __setitem__(self, id, doc):
    if "_id" not in doc:
        doc["_id"] = id
    elif doc["_id"] != id:
        raise ValueError(f"ID '{id}' does not match ID in document")

    return await self.save(doc)
```

but this doesn't work, because we can't `await db["test"] = doc`.