### PR TITLE
Implement Database.get(id, default=None)

### DIFF
--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -31,7 +31,7 @@
 from .bulk import BulkOperation
 from .document import Document
 from .design_document import DesignDocument
-from .exception import ConflictError
+from .exception import ConflictError, NotFoundError
 from .remote import RemoteDatabase
 from .view import AllDocsView, View
 
@@ -114,8 +114,18 @@ class Database(RemoteDatabase):
         return BulkOperation(self, ids, create)
 
     async def __getitem__(self, id):
+        return await self.get(id)
+
+    async def get(self, id, default=None):
         doc = Document(self, id)
-        await doc.fetch(discard_changes=True)
+        try:
+            await doc.fetch(discard_changes=True)
+        except NotFoundError as e:
+            if default is not None:
+                doc.update(default)
+            else:
+                raise e
+
         return doc
 
     async def info(self):


### PR DESCRIPTION
Provide a helper `Database.get()` to allow trading:

```python
try:
    doc = await db["counter"]
except NotFoundError:
    doc = {"_id": "counter", "value": 1}
```

for:

```python
doc = await db.get("counter", {"value": 1})
```

---

*v1 of the pull request:*

~Provide a helper `Database.get()`, similar to couchdb-python [1], to
allow trading:~

```python
try:
    doc = await db["counter"]
except NotFoundError:
    doc = {"_id": "counter", "value": 1}
```

~for:~

```python
doc = await db.get("counter", {"_id": "counter", "value": 1})
```

~\[1]: https://couchdb-python.readthedocs.io/en/latest/client.html#couchdb.client.Database.get~