### PR TITLE
Remove a HTTP call on Database.create(exists_ok=True)

### DIFF
--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -31,7 +31,7 @@
 from .bulk import BulkOperation
 from .document import Document
 from .design_document import DesignDocument
-from .exception import ConflictError
+from .exception import ConflictError, NotFoundError
 from .remote import RemoteDatabase
 from .view import AllDocsView, View
 
@@ -47,10 +47,13 @@ class Database(RemoteDatabase):
     async def create(self, id, exists_ok=False):
         doc = Document(self, id)
 
-        if await doc._exists():
-            if exists_ok:
+        if exists_ok:
+            try:
                 await doc.fetch(discard_changes=True)
-            else:
+            except NotFoundError:
+                pass
+        else:
+            if await doc._exists():
                 raise ConflictError(
                     f"The document '{id}' does already exist in the database '{self.id}'"
                 )


### PR DESCRIPTION
Currently, the problem of `db.create("id", exists_ok=True)` is that it
adds a useless HTTP call if the file already exists:

    await doc._exists()       HEAD /db/id       200 OK
    await doc.fetch()         GET /db/id        200 OK

I propose to remove the first (useless) HEAD request when we're sure we
want to get the full document (`exists_ok=True`). And keep the
lightweight HEAD request when we don't care about its contents
(`exists_ok=False`).