### PR TITLE
Access database._security document

### DIFF
--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -120,3 +120,10 @@ class Database(RemoteDatabase):
 
     async def info(self):
         return await self._get()
+
+    # Document _security is special, it doesn't have _id nor revisions.
+    async def get_security(self):
+        return await self._get_security()
+
+    async def set_security(self, doc):
+        return await self._put_security(doc)

--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -172,6 +172,14 @@ class RemoteDatabase(object):
         data["selector"] = selector
         return await self._remote._post(f"{self.endpoint}/_find", data)
 
+    @raises(401, "Invalid credentials")
+    async def _get_security(self):
+        return await self._remote._get(f"{self.endpoint}/_security")
+
+    @raises(401, "Invalid credentials")
+    async def _put_security(self, doc):
+        return await self._remote._put(f"{self.endpoint}/_security", doc)
+
 
 class RemoteDocument(object):
     def __init__(self, database, id):


### PR DESCRIPTION
Currently, trying to read or write `_security` document using
`db["_security"]` fails, because aiocouch tries to access it as a
regular document. But `_security` is special: it doesn't have `_id` not
`_rev` (it's one of the only documents without revisions).

I propose to implement wrappers to get and set this document:

```python
async with CouchDB() as couch:
    db = await couch["db"]
    print(await db.get_security())
    await db.set_security({
        "members": {"names": ["user1"],
                    "roles": ["db_reader", "db_writer"]},
    })
```

---

PS: About the wording `get_security()` / `set_security()`, your feedback is welcome!