### PR TITLE
Update test command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ Run `pip install .` within the root directory.
 Or shorter for CI:
 
 ```
-COUCHDB_HOST=localhost:5984 COUCHDB_USER=admin COUCHDB_PASS=admin python setup.py test
+COUCHDB_HOST=http://localhost:5984 COUCHDB_USER=admin COUCHDB_PASS=admin python setup.py test
 ```


### PR DESCRIPTION
On my computer, using bare `localhost:5984` fails with:

    aiohttp.client_exceptions.InvalidURL: localhost:5984/...

Using `http://localhost:5984` works.