### PR TITLE
Implement Document.fetch_info() to issue a HEAD request

### DIFF
--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -82,6 +82,9 @@ class Document(RemoteDocument):
     def exists(self):
         return "_rev" in self and "_deleted" not in self
 
+    async def fetch_info(self):
+        return await self._fetch_info()
+
     def _update_rev_after_save(self, data):
         with suppress(KeyError):
             self._data["_rev"] = data["rev"]


### PR DESCRIPTION
There are situations when it's useful to send a tiny HTTP `HEAD /db/doc`
request, to retrieve only the document current revision.

I propose to add a method to retrieve this info:

```python
>>> print(await doc.fetch_info())
{"ok": True,
 "id": "SpaghettiWithMeatballs",
 "rev": "1-917fa2381192822767f010b95b45325b"}
```

The output is similar to what a HTTP `PUT /db/doc` would return.

Note: the new `return_response` argument for `RemoteServer._request()`
will be reused in a future commit (for attachments).