### PR TITLE
Handle document attachments

### DIFF
--- a/aiocouch/attachment.py
+++ b/aiocouch/attachment.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2020, Adrien Vergé
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the documentation
+#       and/or other materials provided with the distribution.
+#     * Neither the name of metricq nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from .remote import RemoteAttachment
+
+
+class Attachment(RemoteAttachment):
+    async def exists(self):
+        return await self._exists()
+
+    async def fetch(self):
+        return await self._get()
+
+    async def save(self, data, content_type):
+        await self._put(await self._get_doc_rev(), data, content_type)
+        # Parent document needs to have '_attachments' and '_rev' updated:
+        await self._document.fetch()
+
+    async def delete(self):
+        await self._delete(await self._get_doc_rev())
+        # Parent document needs to have '_attachments' and '_rev' updated:
+        await self._document.fetch()
+
+    async def _get_doc_rev(self):
+        if not self._document.exists:
+            raise ValueError(
+                "The document must be fetched or saved before updating attachments"
+            )
+
+        return self._document["_rev"]

--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -30,6 +30,7 @@
 
 from .remote import RemoteDocument
 from .exception import ConflictError, ForbiddenError, raises
+from .attachment import Attachment
 
 from contextlib import suppress
 import json
@@ -120,6 +121,11 @@ class Document(RemoteDocument):
 
     def setdefault(self, key, default=None):
         return self._data.setdefault(key, default)
+
+    def attachment(self, id):
+        # Return the attachment object, but don't automatically fetch data over the network
+        # (attachments can be large), let the user call .fetch() or .save().
+        return Attachment(self, id)
 
     def __repr__(self):
         return json.dumps(self._data, indent=2)

--- a/aiocouch/exception.py
+++ b/aiocouch/exception.py
@@ -66,6 +66,9 @@ def raise_for_endpoint(endpoint, message, exception, exception_type=None):
         message_input["id"] = endpoint.id
         message_input["endpoint"] = endpoint.endpoint
         message_input["rev"] = endpoint._data["_rev"]
+    with suppress(KeyError, AttributeError):
+        message_input["document_id"] = endpoint._document.id
+        message_input["document_rev"] = endpoint._document._data["_rev"]
 
     raise exception_type(message.format(**message_input)) from exception
 

--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -65,11 +65,19 @@ class RemoteServer(object):
         self._http_session = aiohttp.ClientSession(headers=headers, auth=auth, **kwargs)
         self._databases = {}
 
-    async def _get(self, path, params=None):
-        return await self._request("GET", path, params=params)
+    async def _get(self, path, params=None, return_response=False):
+        return await self._request(
+            "GET", path, params=params, return_response=return_response
+        )
 
-    async def _put(self, path, data=None, params=None):
-        return await self._request("PUT", path, json=data, params=params)
+    async def _put(self, path, data=None, params=None, content_type=None):
+        if content_type is not None:
+            json, data, headers = None, data, {"Content-Type": content_type}
+        else:
+            json, data, headers = data, None, None
+        return await self._request(
+            "PUT", path, json=json, data=data, params=params, headers=headers
+        )
 
     async def _post(self, path, data, params=None):
         return await self._request("POST", path, json=data, params=params)
@@ -77,17 +85,22 @@ class RemoteServer(object):
     async def _delete(self, path, params=None):
         return await self._request("DELETE", path, params=params)
 
-    async def _head(self, path, params=None):
-        return await self._request("HEAD", path, params=params)
+    async def _head(self, path, params=None, return_response=False):
+        return await self._request(
+            "HEAD", path, params=params, return_response=return_response
+        )
 
-    async def _request(self, method, path, params, **kwargs):
+    async def _request(self, method, path, params, return_response=False, **kwargs):
         kwargs["params"] = _stringify_params(params)
 
         async with self._http_session.request(
             method, url=f"{self._server}{path}", **kwargs
         ) as resp:
             resp.raise_for_status()
-            return await resp.json()
+            if return_response:
+                return resp, await resp.read()
+            else:
+                return await resp.json()
 
     @raises(401, "Invalid credentials")
     async def _all_dbs(self, **params):
@@ -254,6 +267,71 @@ class RemoteDocument(object):
         return await self._database._remote._request(
             "COPY", self.endpoint, params=params, headers={"Destination": destination}
         )
+
+
+class RemoteAttachment(object):
+    def __init__(self, document, id):
+        self._document = document
+        self.id = id
+        self.content_type = None
+
+    @property
+    def endpoint(self):
+        return f"{self._document.endpoint}/{_quote_id(self.id)}"
+
+    @raises(401, "Read privilege required for document '{document_id}'")
+    @raises(403, "Read privilege required for document '{document_id}'")
+    async def _exists(self):
+        try:
+            resp, data = await self._document._database._remote._head(
+                self.endpoint, return_response=True
+            )
+            self.content_type = resp.headers["Content-Type"]
+            return True
+        except aiohttp.ClientResponseError as e:
+            if e.status == 404:
+                return False
+            else:
+                raise e
+
+    @raises(400, "Invalid request parameters")
+    @raises(401, "Read privilege required for document '{document_id}'")
+    @raises(403, "Read privilege required for document '{document_id}'")
+    @raises(404, "Document '{document_id}' or attachment '{id}' doesn’t exists")
+    async def _get(self, **params):
+        resp, data = await self._document._database._remote._get(
+            self.endpoint, params, return_response=True
+        )
+        self.content_type = resp.headers["Content-Type"]
+        return data
+
+    @raises(400, "Invalid request body or parameters")
+    @raises(401, "Write privilege required for document '{document_id}'")
+    @raises(403, "Write privilege required for document '{document_id}'")
+    @raises(404, "Document '{document_id}' doesn’t exists")
+    @raises(
+        409, "Specified revision {document_rev} is not the latest for target document"
+    )
+    async def _put(self, rev, data, content_type, **params):
+        params["rev"] = rev
+        data = await self._document._database._remote._put(
+            self.endpoint, data, params, content_type
+        )
+        self.content_type = content_type
+        return data
+
+    @raises(400, "Invalid request body or parameters")
+    @raises(401, "Write privilege required for document '{document_id}'")
+    @raises(403, "Write privilege required for document '{document_id}'")
+    @raises(404, "Specified database or document ID doesn’t exists ({endpoint})")
+    @raises(
+        409, "Specified revision {document_rev} is not the latest for target document"
+    )
+    async def _delete(self, rev, **params):
+        params["rev"] = rev
+        data = await self._document._database._remote._delete(self.endpoint, params)
+        self.content_type = None
+        return data
 
 
 class RemoteView(object):

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -1,0 +1,132 @@
+from aiocouch import ConflictError, NotFoundError
+from aiocouch.document import Document
+
+import pytest
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+text = (
+    b"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse "
+    b"lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum "
+    b"ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi."
+)
+
+image = (
+    b"RIFF\xb0\x00\x00\x00WEBPVP8 \xa4\x00\x00\x00P\x06\x00\x9d\x01*K\x002\x00?\xfd\xfe\xff"
+    b"\x7f\xbf\xba\xb6\xb2>H\x03\xf0?\x89b\x00\xcc\x1c\x18\x05i\xc1\xdf\xfde\xe3\xfcr\xcb\xbb"
+    b"DX^^\x9f\x9f\xcc/\xd2s]\x9a2j`\xeb\xaa@\x00\xd6\x8c\xfd;\xd5+\x9c\xb8\xb0\x9b\xabM\x07"
+    b"\xc4\xd4\x07b\xcc\x1d\x13\x13\xa3\x9dR?\x9aJe\xe6\x1f\xbf\xed\x17\x19\xdc \x17\x92\xd9"
+    b"\x8eR\x94\xad\x91+\xf1f@\x81\x9a\xcc{\x89\x84;\xd7\xdf\xffk\xea\xc0\xa8\xb9\xe1\xda\xea"
+    b"\xe0\x07\x83\x12&\r\xae)$\x1b\xdc\xe9\xe5\xf0\xb0\xe0a\x0bP\xf1\x04iw\x03a\x86\rM\xe8"
+    b"\xe9\xe0i\x08\xb1\xa0\x00\x00\x00"
+)
+
+
+async def test_save_text(doc):
+    await doc.save()
+    att = doc.attachment("lipsum.txt")
+    await att.save(text, "text/plain")
+
+
+async def test_save_binary(doc):
+    await doc.save()
+    att = doc.attachment("image.webp")
+    await att.save(image, "image/webp")
+
+
+async def test_save_on_unfetched(doc):
+    await doc.save()
+
+    new_doc = Document(doc._database, doc["_id"])
+
+    att = new_doc.attachment("lipsum.txt")
+    with pytest.raises(ValueError):
+        await att.save(text, "text/plain")
+
+    new_doc = await doc._database.get(doc["_id"])
+    att = new_doc.attachment("image.webp")
+    await att.save(text, "text/plain")
+
+
+async def test_get(doc):
+    await doc.save()
+    await doc.attachment("image.webp").save(image, "image/webp")
+
+    att = doc.attachment("image.webp")
+    data = await att.fetch()
+    assert data == image
+    assert att.content_type == "image/webp"
+
+
+async def test_get_on_unfetched(doc):
+    await doc.save()
+    await doc.attachment("image.webp").save(image, "image/webp")
+
+    new_doc = Document(doc._database, doc["_id"])
+    att = new_doc.attachment("image.webp")
+    data = await att.fetch()
+    assert data == image
+
+
+async def test_update(doc):
+    await doc.save()
+
+    doc["value"] = 42
+    await doc.save()
+
+    att = doc.attachment("lipsum.txt")
+    await att.save(text, "text/plain")
+
+    att = doc.attachment("image.webp")
+    await att.save(image, "image/webp")
+
+    doc["value"] = 43
+    await doc.save()
+
+    new_doc = await doc._database.get(doc["_id"])
+    assert new_doc["value"] == 43
+    assert await new_doc.attachment("lipsum.txt").fetch() == text
+    assert await new_doc.attachment("image.webp").fetch() == image
+
+
+async def test_conflict(doc):
+    await doc.save()
+
+    outdated = await doc._database.get(doc["_id"])
+
+    doc["value"] = 42
+    await doc.save()
+
+    with pytest.raises(ConflictError):
+        await outdated.attachment("image.webp").save(image, "image/webp")
+
+    await doc.attachment("image.webp").save(image, "image/webp")
+
+
+async def test_conflict_on_update(doc):
+    await doc.save()
+
+    outdated = await doc._database.get(doc["_id"])
+
+    att = doc.attachment("lipsum.txt")
+    await att.save(text, "text/plain")
+
+    with pytest.raises(ConflictError):
+        await outdated.attachment("image.webp").save(image, "image/webp")
+
+    await doc.attachment("image.webp").save(image, "image/webp")
+
+
+async def test_delete(doc):
+    await doc.save()
+    att = doc.attachment("lipsum.txt")
+    await att.save(text, "text/plain")
+
+    await att.delete()
+
+    att = doc.attachment("lipsum.txt")
+    with pytest.raises(NotFoundError):
+        await att.fetch()
+
+    assert not await att.exists()


### PR DESCRIPTION
See documentation at https://docs.couchdb.org/en/stable/api/document/attachments.html

I choose not to cache data in the class, contrary to `Document` objects,
because attachments can be very large.

For that reason, and for simplicity, file contents are returned directly
from `Attachment.fetch()`, and are sent directly to `.save()`.

The API currently looks like this:

```python
att = doc.attachment("file.webp")
await att.save(binary, "image/webp")

att = doc.attachment("other.html")
data = await att.fetch()
content_type = att.content_type

await att.delete()
```

Criticism and good ideas are welcome!

Closes #18.