### PR TITLE
Fix crash on Document.save() if conflict but not _rev

### DIFF
--- a/aiocouch/exception.py
+++ b/aiocouch/exception.py
@@ -62,13 +62,13 @@ def raise_for_endpoint(endpoint, message, exception, exception_type=None):
 
     message_input = {}
 
-    with suppress(KeyError, AttributeError):
+    with suppress(AttributeError):
         message_input["id"] = endpoint.id
         message_input["endpoint"] = endpoint.endpoint
-        message_input["rev"] = endpoint._data["_rev"]
-    with suppress(KeyError, AttributeError):
+        message_input["rev"] = endpoint._data.get("_rev")
+    with suppress(AttributeError):
         message_input["document_id"] = endpoint._document.id
-        message_input["document_rev"] = endpoint._document._data["_rev"]
+        message_input["document_rev"] = endpoint._document._data.get("_rev")
 
     raise exception_type(message.format(**message_input)) from exception
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -58,6 +58,19 @@ async def test_conflict(filled_database):
         await doc2.save()
 
 
+async def test_conflict_without_rev(database):
+    doc1 = await database.create("fou")
+    doc2 = await database.create("fou")
+
+    doc1["blub"] = "new"
+    await doc1.save()
+
+    doc2["blub"] = "bar"
+
+    with pytest.raises(ConflictError):
+        await doc2.save()
+
+
 async def test_update(filled_database):
     doc = await filled_database["foo"]
 


### PR DESCRIPTION
A common pattern is to try to save a document, and pass if it exists:
```python
try:
    await Document(db, "id").save()
except aiocouch.exception.ConflictError:
    pass
```

Currently, in case of conflict, aiocouch fails with:

    [...]
    aiohttp.client_exceptions.ClientResponseError: 409...
    During handling of the above exception, another exception occurred:
    [...]
    KeyError: 'rev'

I propose to set `rev = None` in error handling, if not available.
Another solution would be to always define `Document._data["_rev"]`, but
this has other implications.