### PR TITLE
Don't use HTTP request if ids list is empty

### DIFF
--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -64,6 +64,8 @@ class Database(RemoteDatabase):
         await self._delete()
 
     async def docs(self, ids=None, create=False, prefix=None, **params):
+        if ids is not None and len(ids) == 0:
+            return
         async for doc in self.all_docs.docs(ids, create, prefix, **params):
             yield doc
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -4,6 +4,15 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
+async def test_update_docs_on_empty(database):
+    async with database.update_docs([]) as bulk:
+        pass
+
+    assert bulk._docs == []
+    keys = [key async for key in database.akeys()]
+    assert len(keys) == 0
+
+
 async def test_update_docs_creating(database):
     async with database.update_docs(["foobar"], create=True):
         pass


### PR DESCRIPTION
The goal is to prevent un-necessary HTTP request to the database when the list
of ids is empty.
It's especially useful when use in combination with `Database.update_docs()`:
```py
with db.update_docs([]) as bulk:
    bulk._docs.append(a_document)
    bulk._docs.append(another_document)
```