### PR TITLE
Remove a HTTP call on Database.design_doc(exists_ok=True)

### DIFF
--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -165,10 +165,11 @@ class Database(RemoteDatabase):
     async def design_doc(self, id, exists_ok=False):
         ddoc = DesignDocument(self, id)
 
-        if await ddoc._exists():
-            if exists_ok:
+        if exists_ok:
+            with suppress(NotFoundError):
                 await ddoc.fetch(discard_changes=True)
-            else:
+        else:
+            if await ddoc._exists():
                 raise ConflictError(
                     f"The design document '{id}' does already exist in the database '{self.id}'"
                 )


### PR DESCRIPTION
In the exact same way commit 724641e avoided a useless HTTP call
on `Database.create(exists_ok=True)`, let's avoid a useless HEAD
request on design documents when we're sure we want to get the full
document content.