### PR TITLE
feat bulk operation: don't crash on pristine document

### DIFF
--- a/aiocouch/bulk.py
+++ b/aiocouch/bulk.py
@@ -55,7 +55,8 @@ class BulkStoreOperation(object):
         self.ok = []
         self.error = []
 
-        for status, doc in zip(self.status, self._docs):
+        docs = [doc for doc in self._docs if doc._dirty_cache]
+        for status, doc in zip(self.status, docs):
             assert status["id"] == doc.id
             if "ok" in status:
                 doc._update_rev_after_save(status)

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -51,6 +51,16 @@ async def test_update_docs_no_change(filled_database):
     assert docs.status == []
 
 
+async def test_update_dont_crash_on_pristine_doc(filled_database):
+    doc = await filled_database["foo"]
+    doc["llama"] = "awesome"
+    await doc.save()
+
+    async with filled_database.update_docs(["foo", "baz"], create=True) as docs:
+        async for doc in docs:
+            doc["llama"] = "awesome"
+
+
 async def test_update_docs_for_deleted(filled_database):
     doc = await filled_database["foo"]
     await doc.delete()


### PR DESCRIPTION
`Database.update_docs(ids=[...])` operation was working without crash only if
all documents were either modified or created.
But if only a subset of documents are really modified inside the bulk operation
it crashed with the error:
```
File "/var/coatl/lib64/python3.8/site-packages/aiocouch/bulk.py", line 59, in __aexit__
	assert status["id"] == doc.id
AssertionError
```
I think it's cool to improve it because:
If you have `foo` and `baz` documents in your db, and want to update both,
but `foo` already have the update. It's a nice shortcut to update both
without having to exclude `foo` from the bulk operation (see unit test for
an example).