### PR TITLE
Feat/Context Managers for Document and Security Document

### DIFF
--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -84,8 +84,7 @@ class Document(RemoteDocument):
 
     async def __aenter__(self) -> "Document":
         # Check the remote server whether the document already exists
-        doc_exists = await self._exists()
-        if doc_exists:
+        if await self._exists():
             await self.fetch(discard_changes=True)
         return self
 

--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -95,7 +95,8 @@ class Document(RemoteDocument):
         traceback: Optional[TracebackType],
     ) -> None:
         with suppress(ConflictError):
-            await self.save()
+            if exc_type is None:
+                await self.save()
 
     def _update_hash(self) -> None:
         self._data_hash = hash(json.dumps(self._data, sort_keys=True))

--- a/docs/document.rst
+++ b/docs/document.rst
@@ -64,6 +64,77 @@ document, updating its contents, and finally saving the modified data to the ser
     # actually perform the request to save the modification to the server
     await doc.save()
 
+
+Using Async Context Managers
+============================
+
+To simplify the process of retrieving a document from remote server (or creating 
+a new one if it didn't exist before), modifying it, and saving changes on remote 
+server, you can also use asynchronous context managers.
+
+Using context managers saves you from having to manually perform a lot of 
+these operations as the context managers handle these operations for you automatically.
+
+**aiocouch** provides async context managers for both :class:`~aiocouch.document.Document`
+and :class:`~aiocouch.document.SecurityDocument`.
+
+
+Document Context Manager Example
+--------------------------------
+
+.. code-block :: python
+
+    from aiocouch import CouchDB
+    from aiocouch.document import Document
+
+    async with CouchDB(SERVER_URL, USER, PASSWORD) as client:
+        # Create database on remote server (fetching it if it already exists)
+        my_database = await client.create("my_database", exists_ok=True)
+
+        # If document exists, it's fetched from the remote server
+        async with Document(my_database, "secret_agents") as document:
+            # Changes are made locally
+            document["name"] = "James Bond"
+            document["code"] = "007"
+        # Upon exit from above context manager, document is saved remotely
+
+        # Display the newly created document after fetching from remote server
+        document = await my_database["secret_agents"]
+        print(document)
+
+.. warning:: Uncaught exceptions inside the ``async with`` block will prevent your
+             document changes from being saved to the remote server.
+
+
+Security Document Context Manager Example
+-----------------------------------------
+
+Similarly, you can also use Security Document context manager to add or remove admins 
+or members from a CouchDB database
+
+.. code-block :: python
+
+    from aiocouch import CouchDB
+    from aiocouch.document import Document
+
+    async with CouchDB(SERVER_URL, USER, PASSWORD) as client:
+        # Create database on remote server (fetching it if it already exists)
+        my_database = await client.create("my_database", exists_ok=True)
+
+        async with SecurityDocument(my_database) as security_doc:
+            # Give user 'bond' member access to 'my_database' database
+            security_doc.add_member("bond")
+            # Give user 'fleming' admin access to 'my_database' database
+            security_doc.add_admin("fleming")
+        # Upon exit from above context manager, document is saved remotely
+
+        # Display the recent changes made to security document        
+        security_doc = await my_database.security()
+        print(security_doc)
+
+.. warning:: Uncaught exceptions inside the ``async with`` block will prevent your
+             security document changes from being saved to the remote server.
+
 Conflict handling
 =================
 

--- a/docs/session.rst
+++ b/docs/session.rst
@@ -13,7 +13,7 @@ Create a session with the context manager
 
 .. code-block :: python
 
-    with aiocouch.CouchDB("http://localhost") as couchdb:
+    async with aiocouch.CouchDB("http://localhost") as couchdb:
         await couchdb.check_credentials()
 
 Note that the session will be closed, once the scope of the with statement is left.

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,4 +1,3 @@
-from tests.conftest import doc
 from typing import Any, cast
 
 import pytest

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -51,27 +51,21 @@ async def test_context_manager_by_creating_new_doc(database: Database) -> None:
     assert saved_doc["king"] == "elvis"
 
 
-async def test_context_manager_by_retrieving_existing_doc(database: Database) -> None:
+async def test_context_manager_by_retrieving_existing_doc(
+    filled_database: Database,
+) -> None:
+    """Test async context manager by retrieving an existing doc from
+    filled_database fixture & verify that data was actually written to server"""
+
     from aiocouch.document import Document
 
-    new_doc_id = "new_doc"
-
-    new_doc = await database.create(new_doc_id)
-    assert new_doc.rev is None
-
-    new_doc["king"] = "elvis"
-
-    await new_doc.save()
-
-    # Test context manager by retrieving existing doc and
-    # Verify that previously saved data was actually written to server
-    async with Document(database=database, id=new_doc_id) as document:
+    async with Document(database=filled_database, id="foo") as document:
         doc_keys = document.keys()
         assert len(doc_keys) == 3
-        assert document["_id"] == document.id == new_doc_id
+        assert document["_id"] == document.id == "foo"
         assert document["_rev"] == document.rev
-        assert "king" in doc_keys
-        assert document["king"] == "elvis"
+        assert "bar" in doc_keys
+        assert document["bar"] is True
 
 
 async def test_context_manager_with_data_parameter(database: Database) -> None:


### PR DESCRIPTION
Adds asynchronous context managers to both Document and Security Document.

These context managers automatically:
- Retrieve the document from the remote server and overwrite local data, if document already exists
- Upon exit, update the remote document with the updated local data, creating a new document if it didn't exist before.
- Don't create/update the document if there were uncaught exceptions in the `with` block.

I've also added the appropriate tests.

An example:
```
async with CouchDB(server=SERVER_URL, user=USER, password=PASSWORD) as couchdb:
    db = await couchdb.create("test_db", exists_ok=True)
    async with Document(database=db, id="new_doc") as doc:
        doc["king"] = "elvis"
```

Inspired from (now deprecated) [python-cloudant](https://github.com/cloudant/python-cloudant). Their examples for reference: [Document Context Manager](https://python-cloudant.readthedocs.io/en/latest/document.html) & [Security Document Context Manager](https://python-cloudant.readthedocs.io/en/latest/security_document.html)

PS: Thank you for this amazing library.