### PR TITLE
Use exists_ok in error handling instead of pre-condition

### DIFF
--- a/aiocouch/couchdb.py
+++ b/aiocouch/couchdb.py
@@ -91,13 +91,13 @@ class CouchDB:
 
         """
         db = Database(self, id)
-        if not await db._exists():
+        try:
             await db._put(**kwargs)
-            return db
-        elif exists_ok:
-            return db
-        else:
-            raise PreconditionFailedError(f"The database '{id}' does already exist.")
+        except PreconditionFailedError as e:
+            if not exists_ok:
+                raise e
+
+        return db
 
     async def __getitem__(self, id: str) -> "Database":
         """Returns a representation for the given database identifier

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,8 +79,15 @@ async def couchdb_with_user_access(
 
 
 @pytest.fixture
-async def database(couchdb: CouchDB) -> AsyncGenerator[Database, None]:
-    database = await couchdb.create("aiocouch_test_fixture_database")
+def database_id() -> str:
+    return "aiocouch_test_fixture_database"
+
+
+@pytest.fixture
+async def database(
+    couchdb: CouchDB, database_id: str
+) -> AsyncGenerator[Database, None]:
+    database = await couchdb.create(database_id)
 
     yield database
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -52,7 +52,7 @@ async def test_create_for_existing_ok_with_race(
     try:
         # try to trigger a race-condition during the creation of the database
         await asyncio.gather(
-            *[couchdb.create(database_id, exists_ok=True) for _ in range(100)]
+            *[couchdb.create(database_id, exists_ok=True) for _ in range(5)]
         )
     finally:
         # for this specific test, we need to do a manual cleanup


### PR DESCRIPTION
In a race condition, the `_exists()` might return `False`, but until the time the `PUT` is done, the database might be created from another context. Hence, just drop the existence check and unconditionally try to create the database.

Fixes #42 