### PR TITLE
Adds ViewResponse dataclass to allow access to all return values

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         couchdb: ["2.3", "3.0", "3.1"]
 
     steps:
@@ -89,10 +89,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.6
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An asynchronous client library for CouchDB 2.0 based on asyncio using aiohttp
 
 - All requests are asynchronus using aiohttp
 - Supports CouchDB 2.x and 3.x
-- Support for modern Python ≥ 3.6
+- Support for modern Python ≥ 3.7
 
 
 ## Library installation

--- a/aiocouch/view.py
+++ b/aiocouch/view.py
@@ -28,9 +28,8 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple, cast
-
 from dataclasses import dataclass
+from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple
 
 from . import database
 from .document import Document

--- a/aiocouch/view.py
+++ b/aiocouch/view.py
@@ -28,7 +28,9 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, cast
+from typing import Any, AsyncGenerator, Dict, Generator, List, Optional, Tuple, cast
+
+from dataclasses import dataclass
 
 from . import database
 from .document import Document
@@ -36,6 +38,51 @@ from .exception import NotFoundError
 from .remote import RemoteView
 
 JsonDict = Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class ViewResponse:
+    offset: int
+    rows: List[JsonDict]
+    total_rows: int
+    update_seq: Any = None
+
+    def keys(self) -> Generator[str, None, None]:
+        for row in self.rows:
+            if "error" not in row:
+                yield row["id"]
+
+    def values(self) -> Generator[Tuple[str, Any], None, None]:
+        for row in self.rows:
+            if "error" not in row:
+                yield row["value"]
+
+    def items(self) -> Generator[Any, None, None]:
+        for row in self.rows:
+            if "error" not in row:
+                yield row["key"], row["value"],
+
+    def docs(
+        self,
+        database: "database.Database",
+        create: bool = False,
+        include_ddocs: bool = False,
+    ) -> Generator[Document, None, None]:
+        for row in self.rows:
+            if "error" not in row and row["doc"] is not None:
+                if row["id"].startswith("_design/") and not include_ddocs:
+                    continue
+                doc = Document(database, row["id"])
+                doc._update_cache(row["doc"])
+                yield doc
+            elif create:
+                doc = Document(database, row["key"])
+                yield doc
+            else:
+                raise NotFoundError(
+                    f"The document '{row['key']}' does not exist in the database "
+                    f"{database.id}."
+                )
 
 
 class View(RemoteView):
@@ -48,19 +95,11 @@ class View(RemoteView):
     def prefix_sentinal(self) -> str:
         return "\uffff"
 
-    async def get(self, **params: Any) -> AsyncGenerator[JsonDict, None]:
-        result_chunk = await self._get(**params)
+    async def get(self, **params: Any) -> ViewResponse:
+        return ViewResponse(**(await self._get(**params)))
 
-        for res in result_chunk["rows"]:
-            yield res
-
-    async def post(
-        self, ids: List[str], create: bool = False, **params: Any
-    ) -> AsyncGenerator[JsonDict, None]:
-        result_chunk = await self._post(ids, **params)
-
-        for res in result_chunk["rows"]:
-            yield res
+    async def post(self, ids: List[str], **params: Any) -> ViewResponse:
+        return ViewResponse(**(await self._post(ids, **params)))
 
     async def ids(
         self,
@@ -73,25 +112,27 @@ class View(RemoteView):
             params["endkey"] = f'"{prefix}{self.prefix_sentinal}"'
 
         if keys is None:
-            async for res in self.get(**params):
-                if "error" not in res:
-                    yield res["id"]
+            response = await self.get(**params)
         else:
-            async for res in self.post(keys, **params):
-                if "error" not in res:
-                    yield res["id"]
+            response = await self.post(keys, **params)
+
+        for key in response.keys():
+            yield key
 
     async def akeys(self, **params: Any) -> AsyncGenerator[str, None]:
-        async for res in self.get(**params):
-            yield res["key"]
+        response = await self.get(**params)
+        for key in response.keys():
+            yield key
 
     async def aitems(self, **params: Any) -> AsyncGenerator[Tuple[str, Any], None]:
-        async for res in self.get(**params):
-            yield cast(str, res["key"]), res["value"]
+        response = await self.get(**params)
+        for key, value in response.items():
+            yield key, value,
 
     async def avalues(self, **params: Any) -> AsyncGenerator[Any, None]:
-        async for res in self.get(**params):
-            yield res["value"]
+        response = await self.get(**params)
+        for value in response.values():
+            yield value
 
     async def docs(
         self,
@@ -104,9 +145,9 @@ class View(RemoteView):
         params["include_docs"] = True
         if prefix is None:
             if ids is None:
-                iter = self.get(**params)
+                response = await self.get(**params)
             else:
-                iter = self.post(ids, **params)
+                response = await self.post(ids, **params)
         else:
             if ids is not None or create:
                 raise ValueError(
@@ -116,23 +157,12 @@ class View(RemoteView):
             params["startkey"] = f'"{prefix}"'
             params["endkey"] = f'"{prefix}{self.prefix_sentinal}"'
 
-            iter = self.get(**params)
+            response = await self.get(**params)
 
-        async for res in iter:
-            if "error" not in res and res["doc"] is not None:
-                if res["id"].startswith("_design/") and not include_ddocs:
-                    continue
-                doc = Document(self._database, res["id"])
-                doc._update_cache(res["doc"])
-                yield doc
-            elif create:
-                doc = Document(self._database, res["key"])
-                yield doc
-            else:
-                raise NotFoundError(
-                    f"The document '{res['key']}' does not exist in the database "
-                    f"{self._database.id}."
-                )
+        for doc in response.docs(
+            self._database, create=create, include_ddocs=include_ddocs
+        ):
+            yield doc
 
 
 class AllDocsView(View):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Key features
 
 - All requests are asynchronus using aiohttp
 - Supports CouchDB 2.x and 3.x
-- Support for modern Python ≥ 3.6
+- Support for modern Python ≥ 3.7
 
 
 Library installation
@@ -76,7 +76,7 @@ Continuous Integration.
 Dependencies
 ============
 
-- Python 3.6+
+- Python 3.7+
 - *aiohttp*
 - *Deprecated*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     Topic :: Database
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -29,7 +28,7 @@ project_urls =
 [options]
 packages =
     aiocouch
-python_requires = >= 3.6
+python_requires = >= 3.7
 include_package_data = True
 setup_requires =
     pytest-runner

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -110,3 +110,13 @@ async def test_null_view_ids_with_prefix(filled_database_with_view: Database) ->
 
     assert values[0] == "baz"
     assert values[1] == "baz2"
+
+
+async def test_view_response_contains_update_seq(
+    filled_database_with_view: Database,
+) -> None:
+    response = await filled_database_with_view.view("test_ddoc", "null_view").get(
+        update_seq=True
+    )
+
+    assert response.update_seq is not None


### PR DESCRIPTION
This PR changes the `View.get()` and  `View.post()` methods to return the new `ViewResponse` `dataclass`. This class looks like the JSON response of the [view endpoint](https://docs.couchdb.org/en/latest/api/ddoc/views.html#db-design-design-doc-view-view-name) but also provides some nice accessor methods to parse the response.


Fixes #45 