### PR TITLE
feat: UTF-8 HTTP Basic authentication (RFC-7617)

### DIFF
--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -74,7 +74,7 @@ class RemoteServer:
         **kwargs: Any,
     ):
         self._server = server
-        auth = aiohttp.BasicAuth(user, password) if user and password else None
+        auth = aiohttp.BasicAuth(user, password, "utf-8") if user and password else None
         headers = {"Cookie": "AuthSession=" + cookie} if cookie else None
         self._http_session = aiohttp.ClientSession(headers=headers, auth=auth, **kwargs)
         # self._databases = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,25 @@ async def couchdb_user_account(couchdb: CouchDB) -> AsyncGenerator[CouchDB, None
 
 
 @pytest.fixture
+async def couchdb_utf8_user_account(couchdb: CouchDB) -> AsyncGenerator[CouchDB, None]:
+    users = await couchdb.create("_users", exists_ok=True)
+
+    doc = await users.create("org.couchdb.user:aiocouch_test_user_🛋️")
+    doc["name"] = "aiocouch_test_user_🛋️"
+    doc["password"] = "aiocouch_test_user_🛋️"
+    doc["roles"] = ["aiocouch_test_role"]
+    doc["type"] = "user"
+
+    await doc.save()
+    assert doc["_id"] == "org.couchdb.user:aiocouch_test_user_🛋️"
+    assert doc.id == "org.couchdb.user:aiocouch_test_user_🛋️"
+
+    yield couchdb
+
+    await doc.delete()
+
+
+@pytest.fixture
 async def couchdb(event_loop: Any) -> AsyncGenerator[CouchDB, None]:
     import asyncio
     import os

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -90,6 +90,18 @@ async def test_basic_authentication() -> None:
         await couchdb.check_credentials()
 
 
+async def test_utf8_basic_authentication(couchdb_utf8_user_account: CouchDB) -> None:
+    try:
+        hostname = os.environ["COUCHDB_HOST"]
+    except KeyError:
+        hostname = "http://localhost:5984"
+
+    user = "aiocouch_test_user_🛋️"
+
+    async with CouchDB(hostname, user=user, password=user) as couchdb:
+        await couchdb.check_credentials()
+
+
 async def test_with_wrong_credentials() -> None:
     import os
 


### PR DESCRIPTION
Username/password encoding in HTTP Basic authentication is broken for non-latin1
char.

UTF-8 Basic authentication is allowed since RFC-7617. Previously, RFC-2616
only allowed to use ISO-8859-1 text which is basically `latin1`.

CouchDB correctly encodes and decodes credentials using UTF-8:
https://github.com/apache/couchdb/blob/0059b8f90e58e10b199a4b768a06a762d12a30d3/dev/pbkdf2.py#L65

aiohttp still uses `latin1` as default:
https://github.com/aio-libs/aiohttp/blob/72d3d4b1f68cca5ad15ef50bffb0419b798c7f23/aiohttp/helpers.py#L139

aiocouch is made for CouchDB, and CouchDB follows RFC-7617, so I think
aiocouch should follow RFC-7617 too.
