### PR TITLE
Redefine the data property of Document instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v3.0.0
+
+- `Document.data` property doesn't contain `_id` and `_rev` anymore [Breaking change]
+- Added `Document.clear` and `Document.__len__` methods
+
 # v2.2.2
 
 - Fixed BasicAuth for UTF-8 encoded credentials
@@ -8,8 +13,8 @@
 
 # v2.2.0
 
-- Added support for /db/_changes endpoint, which allows to listen for change events
-- Added support for /db/_index endpoint, which allows to create indexes on databases
+- Added support for /db/\_changes endpoint, which allows to listen for change events
+- Added support for /db/\_index endpoint, which allows to create indexes on databases
 - Improved documentation
 
 # v2.1.1

--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -280,6 +280,15 @@ class Document(RemoteDocument):
     def update(self, data: JsonDict) -> None:
         self._data.update(data)
 
+    def clear(self) -> None:
+        cleared_data = {"_id": self.id}
+        if self.rev:
+            cleared_data["_rev"] = self.rev
+        self._data = cleared_data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
     def items(self) -> ItemsView[str, Any]:
         return self._data.items()
 

--- a/docs/document.rst
+++ b/docs/document.rst
@@ -55,7 +55,7 @@ document, updating its contents, and finally saving the modified data to the ser
 
 .. code-block :: python
 
-    # get an Document instance
+    # get a Document instance
     doc = await database["existing_doc"]
 
     # update the document content
@@ -63,6 +63,32 @@ document, updating its contents, and finally saving the modified data to the ser
 
     # actually perform the request to save the modification to the server
     await doc.save()
+
+
+The document instance and the data property
+===========================================
+
+Generally speaking, a :class:`~aiocouch.document.Document` instance has the same interface
+as a Python dictionary. It has all the keys and their values that the corresponding document
+on the server had at the time of fetching. The :func:`~aiocouch.document.Document.data`
+property on the other hand only has the actual user-defined data of a document. Logically,
+it is a dictionary constructed from the document instance, but without the ``_id`` and
+``_rev`` entry. This is useful to copy the document content from one instance to another.
+
+.. code-block :: python
+    # get two Document instance
+    doc = await database["existing_doc"]
+    doc2 = await database["another_existing_doc"]
+
+    # update the document content
+    doc.clear()
+    doc.update(doc2.data)
+
+    # safe the change to the server
+    await doc.save()
+
+    # Now, the content of the "existing_doc" document is overwritten 
+    # with the content of the "another_existing_doc" document
 
 
 Using Async Context Managers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,3 +165,11 @@ async def large_filled_database(database: Database) -> AsyncGenerator[Database, 
 async def doc(database: Database) -> AsyncGenerator[Document, None]:
     doc = await database.create("foo")
     yield doc
+
+
+@pytest.fixture
+async def saved_doc(database: Database) -> AsyncGenerator[Document, None]:
+    doc = await database.create("foo")
+    doc["foo"] = "bar"
+    await doc.save()
+    yield doc


### PR DESCRIPTION
This changes the data property not to contain the internal CouchDB entries, i.e., `_id` and `_rev`. This is technically a breaking change, even though the old behavior wasn't adequately documented.