### PR TITLE
Add `json` property to ``Document` class

### DIFF
--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -209,6 +209,22 @@ class Document(RemoteDocument):
         return self._data if self.exists else None
 
     @property
+    def json(self) -> JsonDict:
+        """Returns the document content as a JSON-like dict
+
+        In particular, all CouchDB-internal document keys will be omitted, e.g., ``_id``, ``_rev``
+        If :func:`~aiocouch.document.Document.exists` is ``False``, this function returns an empty dict.
+
+        This method does not perform a network request.
+        """
+
+        return (
+            {key: value for key, value in self._data.items() if not key.startswith("_")}
+            if self.exists
+            else {}
+        )
+
+    @property
     def exists(self) -> bool:
         """Denotes whether the document exists
 

--- a/examples/advanced_connect.py
+++ b/examples/advanced_connect.py
@@ -5,7 +5,6 @@ from aiocouch import CouchDB
 
 # using the with statement, ensures a proper connection handling
 async def main_with() -> None:
-
     # connect using username and password as credentials
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"

--- a/examples/change_events.py
+++ b/examples/change_events.py
@@ -6,7 +6,6 @@ from aiocouch.event import ChangedEvent, DeletedEvent
 
 
 async def main_with() -> None:
-
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -7,7 +7,6 @@ async def main_with() -> None:
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:
-
         print((await couchdb.info())["version"])
 
         database = await couchdb["config"]

--- a/examples/long_running_session.py
+++ b/examples/long_running_session.py
@@ -7,7 +7,6 @@ async def main() -> None:
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:
-
         elapsed_time = 0
 
         while True:

--- a/examples/performance_benchmark.py
+++ b/examples/performance_benchmark.py
@@ -8,7 +8,6 @@ async def main_with() -> None:
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:
-
         database = await couchdb["unfun"]
 
         # selector = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Typing :: Typed
 project_urls =
     Documentation = https://aiocouch.readthedocs.io/en/stable

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -446,3 +446,34 @@ async def test_security_document_context_manager(database: Database) -> None:
 
         assert sec_doc.admins is not None
         assert "elvis" not in sec_doc.admins
+
+
+async def test_data(doc: Document) -> None:
+    assert doc.data is None
+
+    await doc.save()
+
+    assert doc.data is not None
+
+    assert "_id" in doc.data.keys()
+    assert "_rev" in doc.data.keys()
+
+    assert len(doc.data.keys()) == 2
+
+    doc["zebra"] = "🦓"
+
+    assert "zebra" in doc.data.keys()
+
+
+async def test_json(doc: Document) -> None:
+    assert doc.json == {}
+
+    await doc.save()
+
+    assert "_id" not in doc.json.keys()
+    assert "_rev" not in doc.json.keys()
+
+    doc["zebra"] = "🦓"
+
+    assert doc.json != {}
+    assert "zebra" in doc.json

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -477,3 +477,29 @@ async def test_json(doc: Document) -> None:
 
     assert doc.json != {}
     assert "zebra" in doc.json
+
+
+async def test_clone_with_json(filled_database: Database) -> None:
+    foo = await filled_database["foo"]
+
+    clone = await filled_database.create("clone", data=foo.json)
+
+    assert clone.id == "clone"
+    assert clone.rev is None
+    assert clone["bar"] == True
+    assert clone["bar2"] == 3
+
+    clone2 = Document(cast(Database, None), "clone2")
+    clone2.update(foo.json)
+
+    assert clone2.id == "clone2"
+    assert clone2.rev is None
+    assert clone2["bar"] == True
+    assert clone2["bar2"] == 3
+
+    clone3 = Document(cast(Database, None), "clone3", foo.json)
+
+    assert clone3.id == "clone3"
+    assert clone3.rev is None
+    assert clone3["bar"] == True
+    assert clone3["bar2"] == 3


### PR DESCRIPTION
This property provides a convenient way to access the data stored in a document without the CouchDB internals.

Useful to quickly clone documents.

Closes #51 by superseding it.