### PR TITLE
feat: return `HTTPResponse` from certain methods

### DIFF
--- a/aiocouch/__init__.py
+++ b/aiocouch/__init__.py
@@ -41,6 +41,7 @@ from .exception import (
     UnauthorizedError,
     UnsupportedMediaTypeError,
 )
+from .remote import HTTPResponse
 from .view import View
 
 __all__ = [
@@ -48,6 +49,7 @@ __all__ = [
     "Database",
     "Document",
     "View",
+    "HTTPResponse",
     "BadRequestError",
     "ConflictError",
     "UnauthorizedError",

--- a/docs/document.rst
+++ b/docs/document.rst
@@ -171,3 +171,6 @@ Reference
 
 .. autoclass:: aiocouch.document.Document
     :members:
+
+.. autoclass:: aiocouch.remote.HTTPResponse
+    :members:

--- a/examples/advanced_connect.py
+++ b/examples/advanced_connect.py
@@ -5,7 +5,6 @@ from aiocouch import CouchDB
 
 # using the with statement, ensures a proper connection handling
 async def main_with() -> None:
-
     # connect using username and password as credentials
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"

--- a/examples/change_events.py
+++ b/examples/change_events.py
@@ -6,7 +6,6 @@ from aiocouch.event import ChangedEvent, DeletedEvent
 
 
 async def main_with() -> None:
-
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -7,7 +7,6 @@ async def main_with() -> None:
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:
-
         print((await couchdb.info())["version"])
 
         database = await couchdb["config"]

--- a/examples/long_running_session.py
+++ b/examples/long_running_session.py
@@ -7,7 +7,6 @@ async def main() -> None:
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:
-
         elapsed_time = 0
 
         while True:

--- a/examples/performance_benchmark.py
+++ b/examples/performance_benchmark.py
@@ -8,7 +8,6 @@ async def main_with() -> None:
     async with CouchDB(
         "http://localhost:5984", user="admin", password="admin"
     ) as couchdb:
-
         database = await couchdb["unfun"]
 
         # selector = {


### PR DESCRIPTION
These methods are `Document.save()`, `Document.delete()`, and `Document.copy()`.

Breaking change: `Document.copy()` does not return a `Document` anymore. You can use the ETag and fetch the document yourself. Rationale: For efficiency, retrieving the copied document automatically is a bad idea anyways, so returning the response instead does not seem to be an issue. If you need the document, use the ETag, which is a part of the response object, to retrieve it.

Closes #49