### PR TITLE
Use params in _put

### DIFF
--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -246,7 +246,7 @@ class RemoteDatabase:
     @raises(401, "CouchDB Server Administrator privileges required")
     @raises(412, "Database already exists")
     async def _put(self, **params: Any) -> JsonDict:
-        _, json = await self._remote._put(self.endpoint)
+        _, json = await self._remote._put(self.endpoint, **params)
         assert not isinstance(json, bytes)
         return json
 


### PR DESCRIPTION
We want to control database creation, especially the number of shards and the parameter is lost on this line.