### PR TITLE
feat: Add conflicts() method to fetch document open conflicts

### DIFF
--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -281,6 +281,21 @@ class Document(RemoteDocument):
         """
         return await self._info()
 
+    async def conflicts(self) -> List[str]:
+        """Returns conflicting revisions for the document.
+
+        This method sends a request to the server to retrieve unresolved
+        conflicts for the document.
+
+        An empty array means that there is no unresolved conflicts.
+
+        :raises ~aiocouch.NotFoundError: if the document does not exist on the server
+
+        :return: An array containing the conflicting revisions of the document on the server
+
+        """
+        return await self._conflicts()
+
     def _update_rev_after_save(self, data: JsonDict) -> None:
         with suppress(KeyError):
             self._data["_rev"] = data["rev"]

--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -432,6 +432,15 @@ class RemoteDocument:
         assert not isinstance(json, bytes)
         return (response, json)
 
+    @raises(400, "The format of the request or revision was invalid")
+    @raises(401, "Read privilege required for document '{id}'")
+    @raises(403, "Read privilege required for document '{id}'")
+    @raises(404, "Document {id} was not found")
+    async def _conflicts(self) -> List[str]:
+        json = await self._get(conflicts=True)
+        assert not isinstance(json, bytes)
+        return cast(List[str], json.get("_conflicts", []))
+
 
 class RemoteAttachment:
     def __init__(self, document: "document.Document", id: str):


### PR DESCRIPTION
This commit adds a way to check if there are unresolved conflicts for a
document. Conflicting revisions are fetched on the server by making a GET
request of the document with `conflicts=true` in the request parameters.

See the [CouchDB documentation for fetching documents] for more info on this.

[CouchDB documentation for fetching documents]:
https://docs.couchdb.org/en/stable/api/document/common.html#get--db-docid

Closes https://github.com/metricq/aiocouch/issues/58