### PR TITLE
feat: Add revs() method to fetch document known revs

### DIFF
--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -296,6 +296,19 @@ class Document(RemoteDocument):
         """
         return await self._conflicts()
 
+    async def revs(self) -> List[str]:
+        """Returns the list of all known revisions for the document.
+
+        This method sends a request to the server to retrieve known
+        revisions for the document.
+
+        :raises ~aiocouch.NotFoundError: if the document does not exist on the server
+
+        :return: An array containing the known revisions of the document on the server
+
+        """
+        return await self._revs()
+
     def _update_rev_after_save(self, data: JsonDict) -> None:
         with suppress(KeyError):
             self._data["_rev"] = data["rev"]

--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -441,6 +441,15 @@ class RemoteDocument:
         assert not isinstance(json, bytes)
         return cast(List[str], json.get("_conflicts", []))
 
+    @raises(400, "The format of the request or revision was invalid")
+    @raises(401, "Read privilege required for document '{id}'")
+    @raises(403, "Read privilege required for document '{id}'")
+    @raises(404, "Document {id} was not found")
+    async def _revs(self) -> List[str]:
+        json = await self._get(revs_info=True)
+        assert not isinstance(json, bytes)
+        return cast(List[str], [item["rev"] for item in json.get("_revs_info", [])])
+
 
 class RemoteAttachment:
     def __init__(self, document: "document.Document", id: str):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -274,6 +274,30 @@ async def test_list_conflicts(database: Database) -> None:
     assert conflicts == []
 
 
+async def test_list_revs(database: Database) -> None:
+    doc = await database.create("revisions")
+
+    assert doc.rev is None
+    with pytest.raises(NotFoundError):
+        await doc.revs()
+
+    doc["v"] = "1"
+    await doc.save()
+    assert doc.rev is not None
+    assert doc.rev.startswith("1-")
+    revs = await doc.revs()
+    assert revs == ["1-806db366bc1ba3ebef40f4b7c63a53af"]
+
+    doc["v"] = "2"
+    await doc.save()
+    assert doc.rev.startswith("2-")
+    revs = await doc.revs()
+    assert revs == [
+        "2-8ef50bd631ee32d350edd37cd66f2e31",
+        "1-806db366bc1ba3ebef40f4b7c63a53af",
+    ]
+
+
 async def test_update(filled_database: Database) -> None:
     doc = await filled_database["foo"]
 


### PR DESCRIPTION
This commit adds a way to list known revisions for a document on the server.    
Known revisions are fetched on the server by making a GET request of the        
document with `revs_info=true` in the request parameters.                       
                                                                                
note: we could also use `revs=true` in the request to get similar results, but  
      the CouchDB response in this case is harder to process. The result is the 
      same in both case, so I went with the option leading to less code.        
                                                                                
See the [CouchDB documentation for fetching documents] for more info on this.   
                                                                                
[CouchDB documentation for fetching documents]:                                 
https://docs.couchdb.org/en/stable/api/document/common.html#get--db-docid       
                                                                                
Initially discussed in #58 