### PR TITLE
Changes the API to require kwargs, instead of accepting args

### DIFF
--- a/aiocouch/bulk.py
+++ b/aiocouch/bulk.py
@@ -119,7 +119,7 @@ class BulkOperation:
         for doc in self._docs:
             yield doc
 
-    def create(self, id: str, data: Optional[JsonDict] = None) -> Document:
+    def create(self, id: str, *, data: Optional[JsonDict] = None) -> Document:
         """Create a new document as part of the bulk operation
 
         :param id: the id of the document
@@ -203,7 +203,11 @@ class BulkUpdateOperation(BulkOperation):
     """
 
     def __init__(
-        self, database: "database.Database", ids: List[str] = [], create: bool = False
+        self,
+        database: "database.Database",
+        ids: List[str] = [],
+        *,
+        create: bool = False,
     ):
         super().__init__(database=database)
         self._ids = ids

--- a/aiocouch/couchdb.py
+++ b/aiocouch/couchdb.py
@@ -78,7 +78,7 @@ class CouchDB:
         await self._server.close()
 
     async def create(
-        self, id: str, exists_ok: bool = False, **params: Any
+        self, id: str, *, exists_ok: bool = False, **params: Any
     ) -> "Database":
         """Creates a new database on the server
 

--- a/aiocouch/database.py
+++ b/aiocouch/database.py
@@ -86,7 +86,7 @@ class Database(RemoteDatabase):
             yield key
 
     async def create(
-        self, id: str, exists_ok: bool = False, data: Optional[JsonDict] = None
+        self, id: str, *, exists_ok: bool = False, data: Optional[JsonDict] = None
     ) -> "Document":
         """Returns a local representation of a new document in the database
 
@@ -131,6 +131,7 @@ class Database(RemoteDatabase):
     async def docs(
         self,
         ids: Optional[List[str]] = None,
+        *,
         create: bool = False,
         prefix: Optional[str] = None,
         include_ddocs: bool = False,
@@ -158,7 +159,7 @@ class Database(RemoteDatabase):
             return
 
         async for doc in self.all_docs.docs(
-            ids, create, prefix, include_ddocs, **params
+            ids, create=create, prefix=prefix, include_ddocs=include_ddocs, **params
         ):
             yield doc
 
@@ -182,7 +183,7 @@ class Database(RemoteDatabase):
     def view(self, design_doc: str, view: str) -> View:
         return View(self, design_doc, view)
 
-    async def design_doc(self, id: str, exists_ok: bool = False) -> DesignDocument:
+    async def design_doc(self, id: str, *, exists_ok: bool = False) -> DesignDocument:
         ddoc = DesignDocument(self, id)
 
         if exists_ok:
@@ -197,7 +198,7 @@ class Database(RemoteDatabase):
         return ddoc
 
     async def find(
-        self, selector: Any, limit: Optional[int] = None, **params: Any
+        self, selector: Any, *, limit: Optional[int] = None, **params: Any
     ) -> AsyncGenerator["Document", None]:
         """Fetch documents based on search criteria
 
@@ -218,7 +219,7 @@ class Database(RemoteDatabase):
         if "fields" in params.keys():
             raise ValueError("The fields parameter isn't supported")
 
-        async for doc in FindRequest(self, selector, limit, **params):
+        async for doc in FindRequest(self, selector, limit=limit, **params):
             yield doc
 
     async def index(self, index: JsonDict, **kwargs: Any) -> JsonDict:
@@ -238,7 +239,7 @@ class Database(RemoteDatabase):
 
     @_returns_async_context_manager
     def update_docs(
-        self, ids: List[str] = [], create: bool = False
+        self, ids: List[str] = [], *, create: bool = False
     ) -> AsyncContextManager[BulkUpdateOperation]:
         """Update documents in bulk.
 
@@ -250,7 +251,7 @@ class Database(RemoteDatabase):
 
         """
 
-        return BulkUpdateOperation(self, ids, create)
+        return BulkUpdateOperation(self, ids, create=create)
 
     @_returns_async_context_manager
     def create_docs(
@@ -279,7 +280,7 @@ class Database(RemoteDatabase):
         return await self.get(id)
 
     async def get(
-        self, id: str, default: Optional[JsonDict] = None, *, rev: Optional[str] = None
+        self, id: str, *, default: Optional[JsonDict] = None, rev: Optional[str] = None
     ) -> Document:
         """Returns the document with the given id
 
@@ -327,7 +328,7 @@ class Database(RemoteDatabase):
         return await self._get()
 
     async def changes(
-        self, last_event_id: Optional[str] = None, **params: Any
+        self, *, last_event_id: Optional[str] = None, **params: Any
     ) -> AsyncGenerator[BaseChangeEvent, None]:
         """Listens for events made to documents of this database
 

--- a/aiocouch/design_document.py
+++ b/aiocouch/design_document.py
@@ -65,9 +65,9 @@ class DesignDocument(Document):
     async def create_view(
         self,
         view: str,
+        *,
         map_function: str,
         reduce_function: Optional[str] = None,
-        *,
         exists_ok: bool = False,
     ) -> View:
         if "views" not in self:

--- a/aiocouch/design_document.py
+++ b/aiocouch/design_document.py
@@ -67,6 +67,7 @@ class DesignDocument(Document):
         view: str,
         map_function: str,
         reduce_function: Optional[str] = None,
+        *,
         exists_ok: bool = False,
     ) -> View:
         if "views" not in self:

--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -99,7 +99,7 @@ class Document(RemoteDocument):
         )
 
     async def fetch(
-        self, discard_changes: bool = False, *, rev: Optional[str] = None
+        self, *, discard_changes: bool = False, rev: Optional[str] = None
     ) -> None:
         """Retrieves the document data from the server
 
@@ -147,7 +147,7 @@ class Document(RemoteDocument):
 
         return None
 
-    async def delete(self, discard_changes: bool = False) -> HTTPResponse:
+    async def delete(self, *, discard_changes: bool = False) -> HTTPResponse:
         """Marks the document as deleted on the server
 
         Calling this method deletes the local data and marks document as deleted on

--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -367,8 +367,8 @@ class Document(RemoteDocument):
 
 
 class SecurityDocument(Document):
-    def __init__(self, database: "database.Database"):
-        super().__init__(database, "_security")
+    def __init__(self, database: "database.Database", **kwargs: Any):
+        super().__init__(database, "_security", **kwargs)
         del self._data["_id"]
 
     async def __aenter__(self) -> "SecurityDocument":

--- a/aiocouch/document.py
+++ b/aiocouch/document.py
@@ -62,7 +62,7 @@ class Document(RemoteDocument):
     """
 
     def __init__(
-        self, database: "database.Database", id: str, data: Optional[JsonDict] = None
+        self, database: "database.Database", id: str, *, data: Optional[JsonDict] = None
     ):
         super().__init__(database, id)
         self._data: JsonDict = data if data is not None else {}

--- a/aiocouch/event.py
+++ b/aiocouch/event.py
@@ -84,7 +84,7 @@ class ChangedEvent(BaseChangeEvent):
             # if in the request include_docs was given, we can create the
             # document on the spot...
             return document.Document(
-                self.database, self.json["doc"]["_id"], self.json["doc"]
+                self.database, self.json["doc"]["_id"], data=self.json["doc"]
             )
         except KeyError:
             # ...otherwise, we fetch the document contents from the server

--- a/aiocouch/remote.py
+++ b/aiocouch/remote.py
@@ -298,7 +298,7 @@ class RemoteDatabase:
     @raises(403, "Access forbidden: {reason}")
     @raises(404, "Invalid database name")
     @raises(415, "Bad Content-Type value")
-    async def _bulk_get(self, docs: List[str], **params: Any) -> JsonDict:
+    async def _bulk_get(self, docs: List[JsonDict], **params: Any) -> JsonDict:
         _, json = await self._remote._post(
             f"{self.endpoint}/_bulk_get",
             data={"docs": docs},

--- a/aiocouch/request.py
+++ b/aiocouch/request.py
@@ -36,7 +36,11 @@ from .document import Document
 
 class FindRequestChunk:
     def __init__(
-        self, database: "database.Database", data: Dict[str, Any], pagination_size: int
+        self,
+        database: "database.Database",
+        *,
+        data: Dict[str, Any],
+        pagination_size: int,
     ):
         self.database = database
         self.data = data
@@ -78,10 +82,12 @@ class FindRequest:
         while True:
             chunk = FindRequestChunk(
                 self.database,
-                await self.database._find(
-                    self.selector, limit=pagination_size, **self.params
+                data=await self.database._find(
+                    self.selector,
+                    limit=pagination_size,
+                    **self.params,
                 ),
-                pagination_size,
+                pagination_size=pagination_size,
             )
 
             self.params["bookmark"] = chunk.bookmark

--- a/aiocouch/request.py
+++ b/aiocouch/request.py
@@ -63,6 +63,7 @@ class FindRequest:
         self,
         database: "database.Database",
         selector: Any,
+        *,
         limit: Optional[int] = None,
         **params: Any,
     ):

--- a/aiocouch/view.py
+++ b/aiocouch/view.py
@@ -64,6 +64,7 @@ class ViewResponse:
 
     def docs(
         self,
+        *,
         create: bool = False,
         include_ddocs: bool = False,
     ) -> Generator[Document, None, None]:
@@ -117,6 +118,7 @@ class View(RemoteView):
     async def ids(
         self,
         ids: Optional[List[str]] = None,
+        *,
         prefix: Optional[str] = None,
         **params: Any,
     ) -> AsyncGenerator[str, None]:
@@ -140,6 +142,7 @@ class View(RemoteView):
     async def docs(
         self,
         ids: Optional[List[str]] = None,
+        *,
         create: bool = False,
         prefix: Optional[str] = None,
         include_ddocs: bool = False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,9 +143,18 @@ async def filled_database_with_view(
     filled_database: Database,
 ) -> AsyncGenerator[Database, None]:
     ddoc = await filled_database.design_doc("test_ddoc")
-    await ddoc.create_view("null_view", "function (doc) { emit(doc._id, null); }")
-    await ddoc.create_view("full_view", "function (doc) { emit(doc._id, doc); }")
-    await ddoc.create_view("bar_view", "function (doc) { emit(doc._id, doc.bar); }")
+    await ddoc.create_view(
+        "null_view",
+        map_function="function (doc) { emit(doc._id, null); }",
+    )
+    await ddoc.create_view(
+        "full_view",
+        map_function="function (doc) { emit(doc._id, doc); }",
+    )
+    await ddoc.create_view(
+        "bar_view",
+        map_function="function (doc) { emit(doc._id, doc.bar); }",
+    )
 
     yield filled_database
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -226,3 +226,28 @@ async def test_no_bulk_request_on_exception(database: Database, doc: Document) -
     # check that the changes were not send to the server
     doc2 = await database.create(doc.id)
     assert "zebras" not in doc2
+
+
+async def test_bulk_get(filled_database: Database) -> None:
+    response = await filled_database._bulk_get(
+        [{"id": id} for id in ["foo", "foo2", "baz", "baz2", "bar"]]
+    )
+
+    results = response["results"]
+
+    assert len(results) == 5
+
+    assert results[0]["id"] == "foo"
+    assert "ok" in results[0]["docs"][0]
+
+    assert results[1]["id"] == "foo2"
+    assert "ok" in results[1]["docs"][0]
+
+    assert results[2]["id"] == "baz"
+    assert "ok" in results[2]["docs"][0]
+
+    assert results[3]["id"] == "baz2"
+    assert "ok" in results[3]["docs"][0]
+
+    assert results[4]["id"] == "bar"
+    assert "error" in results[4]["docs"][0]

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -52,7 +52,7 @@ async def test_create_for_existing(filled_database: Database) -> None:
 
 
 async def test_create_for_existing_exists_true(filled_database: Database) -> None:
-    doc = await filled_database.create("foo", True)
+    doc = await filled_database.create("foo", exists_ok=True)
 
     assert doc["bar"] is True
     assert doc["_id"] == doc.id == "foo"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,9 @@
+from typing import cast
+
 import pytest
 
 from aiocouch.database import Database
+from aiocouch.document import SecurityDocument
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
@@ -328,12 +331,26 @@ async def test_set_invalid_design_doc_key(filled_database_with_view: Database) -
 
 async def test_get_security(database: Database) -> None:
     sec = await database.security()
+    sec2 = SecurityDocument(cast(Database, None), data=await database._get_security())
 
     assert sec.members is None
+    assert sec2.members is None
     assert sec.admins is None
+    assert sec2.admins is None
 
     assert sec.member_roles is None or sec.member_roles == ["_admin"]
+    assert sec2.member_roles is None or sec2.member_roles == ["_admin"]
     assert sec.admin_roles is None or sec.admin_roles == ["_admin"]
+    assert sec2.admin_roles is None or sec2.admin_roles == ["_admin"]
+
+
+async def test_set_security(database: Database) -> None:
+    sec = await database.security()
+
+    result = await database._put_security(sec._data)
+
+    assert "ok" in result
+    assert result["ok"] is True
 
 
 async def test_security_add_members(database: Database) -> None:

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -585,7 +585,7 @@ async def test_clone_with_json(filled_database: Database) -> None:
 
     assert clone.id == "clone"
     assert clone.rev is None
-    assert clone["bar"] == True
+    assert clone["bar"] is True
     assert clone["bar2"] == 3
 
     clone2 = Document(cast(Database, None), "clone2")
@@ -593,12 +593,12 @@ async def test_clone_with_json(filled_database: Database) -> None:
 
     assert clone2.id == "clone2"
     assert clone2.rev is None
-    assert clone2["bar"] == True
+    assert clone2["bar"] is True
     assert clone2["bar2"] == 3
 
-    clone3 = Document(cast(Database, None), "clone3", foo.json)
+    clone3 = Document(cast(Database, None), "clone3", data=foo.json)
 
     assert clone3.id == "clone3"
     assert clone3.rev is None
-    assert clone3["bar"] == True
+    assert clone3["bar"] is True
     assert clone3["bar2"] == 3

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -83,14 +83,19 @@ async def test_create_existing_view(filled_database_with_view: Database) -> None
     ddoc = await filled_database_with_view.design_doc("test_ddoc", exists_ok=True)
 
     with pytest.raises(KeyError):
-        await ddoc.create_view("null_view", "function (doc) { emit(doc._id, null); }")
+        await ddoc.create_view(
+            "null_view",
+            map_function="function (doc) { emit(doc._id, null); }",
+        )
 
 
 async def test_create_view_with_reduce(database: Database) -> None:
     ddoc = await database.design_doc("my_test_ddoc")
 
     await ddoc.create_view(
-        "my_test_view", "function (doc) { emit(doc._id, null); }", "_count"
+        "my_test_view",
+        map_function="function (doc) { emit(doc._id, null); }",
+        reduce_function="_count",
     )
 
 


### PR DESCRIPTION
Many functions accept parameters that change their behavior, but are separate from input data to work on, for example `exists_ok`, `create`. This commit enforces that these parameters must be passed as named parameters (kwargs).

Breaking change: While this is technically a breaking change, all but one test cases have always been written like this. No parameters have been added, renamed or removed. So I'd expect a smooth transition in most cases.